### PR TITLE
update build.gradle buildToolsVersion to 28.0.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
this change is needed to update react native version to 0.63, because RN project now has com.android.tools.build:gradle version 3.5.3, which the minimum compatible version is 28.0.3